### PR TITLE
Refactor plant editor into multi-step flow

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,158 +165,82 @@
         </div>
       </section>
 
-      <section id="editorView" class="view">
-        <form id="plantForm" class="card" autocomplete="off">
-          <input type="hidden" id="plantId" />
-          <div class="row">
-            <label for="plantName">Name</label>
-            <input id="plantName" required placeholder="e.g., Monstera" class="px-3 py-2 rounded-xl border" />
-          </div>
-          <div class="row">
-            <div class="actions" style="justify-content:flex-start; gap:.5rem; margin-bottom:.5rem">
-              <button type="button" id="generatePlanBtn" class="btn primary">AI Care Plan</button>
-            </div>
-            <label>Taxonomy</label>
-            <div class="grid-3">
-              <input id="plantFamily" placeholder="Family e.g., Araceae" class="px-3 py-2 rounded-xl border" />
-              <input id="plantGenus" placeholder="Genus e.g., Monstera" class="px-3 py-2 rounded-xl border" />
-              <input id="plantSpecies" placeholder="Species e.g., deliciosa" class="px-3 py-2 rounded-xl border" />
-            </div>
-            <div class="actions" style="justify-content:flex-start; gap:.5rem; margin-top:.5rem">
-              <button type="button" id="suggestTaxonomy" class="btn">Suggest Taxonomy</button>
-            </div>
-            <div id="taxoSuggestions" class="taxo-suggestions"></div>
-          </div>
-          <div class="row">
-            <label for="cultivar">Cultivar</label>
-            <input id="cultivar" placeholder="e.g., 'Albo Variegata'" class="px-3 py-2 rounded-xl border" />
-            <div class="actions" style="justify-content:flex-start; gap:.5rem; margin-top:.5rem">
-              <button type="button" id="suggestCultivar" class="btn">Suggest Cultivar</button>
-            </div>
-            <div id="cultivarSuggestions" class="taxo-suggestions"></div>
-          </div>
-          <div class="row">
-            <label for="potDiameter">Pot diameter (in)</label>
-            <input id="potDiameter" type="number" min="1" step="0.5" placeholder="6" class="px-3 py-2 rounded-xl border" />
-          </div>
-          <div class="row">
-            <label for="baseInterval">Base water interval (days)</label>
-            <input id="baseInterval" type="number" min="1" step="1" value="7" required class="px-3 py-2 rounded-xl border" />
-          </div>
-          <div class="row">
-            <label for="lightLevel">Light level</label>
-            <select id="lightLevel" class="px-3 py-2 rounded-xl border">
-              <option value="low">Low</option>
-              <option value="medium" selected>Medium</option>
-              <option value="high">High</option>
-            </select>
-          </div>
-          <div class="row">
-            <label for="potSize">Pot size</label>
-            <select id="potSize" class="px-3 py-2 rounded-xl border">
-              <option value="small">Small</option>
-              <option value="medium" selected>Medium</option>
-              <option value="large">Large</option>
-            </select>
-          </div>
-          <div class="row">
-            <label>Soil & Location</label>
-            <div class="grid-3">
-              <select id="soilType" class="px-3 py-2 rounded-xl border">
-                <option value="generic" selected>Generic potting mix</option>
-                <option value="aroid">Aroid/tropical mix</option>
-                <option value="cactus">Cactus/succulent mix</option>
-              </select>
-              <select id="exposure" class="px-3 py-2 rounded-xl border">
-                <option value="">Exposure (optional)</option>
-                <option value="N">North</option>
-                <option value="E">East</option>
-                <option value="S">South</option>
-                <option value="W">West</option>
-              </select>
-              <select id="inout" class="px-3 py-2 rounded-xl border">
-                <option value="indoor" selected>Indoor</option>
-                <option value="outdoor">Outdoor</option>
-              </select>
-            </div>
-            <div class="row" style="margin-top:.5rem">
-              <input id="roomLabel" placeholder="Room / location (optional)" class="px-3 py-2 rounded-xl border" />
-            </div>
-            <div class="actions" style="justify-content:flex-start; gap:.5rem; margin-top:.5rem">
-              <button type="button" id="usePlantWeather" class="btn">Use Weather for this Plant</button>
-              <button type="button" id="clearPlantWeather" class="btn">Clear Plant Weather</button>
-              <span id="plantWeatherTag" class="muted"></span>
-            </div>
-            <div class="grid-3" style="margin-top:.5rem">
-              <input id="plantLat" type="number" step="0.0001" placeholder="Latitude (optional)" class="px-3 py-2 rounded-xl border" />
-              <input id="plantLon" type="number" step="0.0001" placeholder="Longitude (optional)" class="px-3 py-2 rounded-xl border" />
-              <div class="muted">Outdoor plants can use custom coords</div>
-            </div>
-          </div>
-          <div class="row">
-            <label>Fine-tuning</label>
-            <div class="grid-3">
-              <input id="tuneIntervalPct" type="number" step="1" min="-50" max="50" placeholder="Interval % (e.g., -10 or 10)" class="px-3 py-2 rounded-xl border" />
-              <input id="tuneVolumePct" type="number" step="1" min="-50" max="50" placeholder="Volume % (e.g., -10 or 10)" class="px-3 py-2 rounded-xl border" />
-              <div></div>
-            </div>
-          </div>
-          <div class="row">
-            <label for="lastWatered">Last watered</label>
-            <input id="lastWatered" type="date" class="px-3 py-2 rounded-xl border" />
-          </div>
-          <div class="row">
-            <label>Watering Recommendation</label>
-            <div id="waterRec" class="muted">—</div>
-          </div>
-          <div class="row">
-            <label>Tasks</label>
-            <div class="grid-3">
-              <div class="task-field">
-                <select id="task1Type">
-                  <option value="">— none —</option>
-                  <option value="fertilize">Fertilize</option>
-                  <option value="repot">Repot</option>
-                  <option value="prune">Prune</option>
-                  <option value="inspect">Inspect</option>
-                  <option value="mist">Mist</option>
-                </select>
-                <input id="task1Every" type="number" min="1" step="1" placeholder="Every (days)" />
-              </div>
-              <div class="task-field">
-                <select id="task2Type">
-                  <option value="">— none —</option>
-                  <option value="fertilize">Fertilize</option>
-                  <option value="repot">Repot</option>
-                  <option value="prune">Prune</option>
-                  <option value="inspect">Inspect</option>
-                  <option value="mist">Mist</option>
-                </select>
-                <input id="task2Every" type="number" min="1" step="1" placeholder="Every (days)" />
-              </div>
-              <div class="task-field">
-                <select id="task3Type">
-                  <option value="">— none —</option>
-                  <option value="fertilize">Fertilize</option>
-                  <option value="repot">Repot</option>
-                  <option value="prune">Prune</option>
-                  <option value="inspect">Inspect</option>
-                  <option value="mist">Mist</option>
-                </select>
-                <input id="task3Every" type="number" min="1" step="1" placeholder="Every (days)" />
-              </div>
-            </div>
-          </div>
-          <div class="row">
-            <label for="notes">Notes</label>
-            <textarea id="notes" rows="3" placeholder="Soil mix, location, etc."></textarea>
-          </div>
-          <div class="actions">
-            <button type="button" class="btn" id="cancelEdit">Cancel</button>
-            <button type="submit" class="btn primary">Save</button>
-          </div>
-        </form>
-      </section>
+      
+<section id="editorView" class="view">
+  <div class="card" id="editorSteps">
+    <div class="step" data-step="1" id="stepIdentify">
+      <h2 class="text-xl mb-2">Identify</h2>
+      <input id="plantName" placeholder="Plant name" class="px-3 py-2 rounded-xl border w-full mb-2" />
+      <input id="plantPhoto" type="file" accept="image/*" capture="environment" class="mb-2" />
+      <div class="actions gap-2 mb-2">
+        <button type="button" id="lookupTaxonomy" class="btn">Lookup</button>
+      </div>
+      <div id="taxoResults" class="taxo-suggestions mb-4"></div>
+      <div class="actions gap-2">
+        <button type="button" class="btn" id="cancelEdit">Cancel</button>
+        <button type="button" data-next class="btn primary">Next</button>
+      </div>
+    </div>
+    <div class="step hidden" data-step="2" id="stepLocation">
+      <h2 class="text-xl mb-2">Location</h2>
+      <div id="locationChips" class="flex flex-wrap gap-2 mb-4">
+        <button type="button" class="chip" data-loc="Living Room">Living Room</button>
+        <button type="button" class="chip" data-loc="Kitchen">Kitchen</button>
+        <button type="button" class="chip" data-loc="Bedroom">Bedroom</button>
+      </div>
+      <label class="flex items-center gap-2 mb-4"><input type="checkbox" id="isOutdoor" />Outdoor</label>
+      <div class="actions gap-2 mb-4">
+        <button type="button" id="fetchWeather" class="btn">Fetch Weather</button>
+        <button type="button" id="clearWeather" class="btn">Clear</button>
+        <span id="weatherTag" class="muted"></span>
+      </div>
+      <div class="actions gap-2">
+        <button type="button" data-prev class="btn">Back</button>
+        <button type="button" data-next class="btn primary">Next</button>
+      </div>
+    </div>
+    <div class="step hidden" data-step="3" id="stepPot">
+      <h2 class="text-xl mb-2">Pot & Soil</h2>
+      <div class="grid-2 gap-2 mb-4">
+        <select id="potSize" class="px-3 py-2 rounded-xl border">
+          <option value="4">4"</option>
+          <option value="6" selected>6"</option>
+          <option value="8">8"</option>
+          <option value="10">10"</option>
+        </select>
+        <select id="soilType" class="px-3 py-2 rounded-xl border">
+          <option value="generic" selected>Generic potting mix</option>
+          <option value="aroid">Aroid/tropical mix</option>
+          <option value="cactus">Cactus/succulent mix</option>
+        </select>
+      </div>
+      <label class="flex items-center gap-2 mb-4"><input type="checkbox" id="hasDrain" checked />Drainage holes</label>
+      <div class="actions gap-2">
+        <button type="button" data-prev class="btn">Back</button>
+        <button type="button" data-next class="btn primary">Next</button>
+      </div>
+    </div>
+    <div class="step hidden" data-step="4" id="stepScience">
+      <h2 class="text-xl mb-2">Science Panel</h2>
+      <div id="carePlanDetails" class="muted mb-4">No plan</div>
+      <div class="actions gap-2 mb-4">
+        <button type="button" id="genCarePlan" class="btn">Generate Plan</button>
+      </div>
+      <div class="actions gap-2">
+        <button type="button" data-prev class="btn">Back</button>
+        <button type="button" data-next class="btn primary">Next</button>
+      </div>
+    </div>
+    <div class="step hidden" data-step="5" id="stepConfirm">
+      <h2 class="text-xl mb-2">Confirm</h2>
+      <div id="confirmSummary" class="mb-4"></div>
+      <div class="actions gap-2">
+        <button type="button" data-prev class="btn">Back</button>
+        <button type="button" id="addSpecimen" class="btn primary">Add Specimen</button>
+      </div>
+    </div>
+  </div>
+</section>
     </main>
 
     <!-- Modal removed in favor of full detail view -->


### PR DESCRIPTION
## Summary
- Replace monolithic plant form with five-step editor (identify, location, pot & soil, science panel, confirm)
- Overhaul editor logic to handle step navigation, taxonomy lookup, weather fetch, AI care-plan generation, and final add action
- Update scheduling helpers to use pot-size categories and AI-derived intervals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b26cd69e708324ae275d5cf7419457