### PR TITLE
Add accessible progress indicator for editor steps

### DIFF
--- a/app.js
+++ b/app.js
@@ -70,6 +70,16 @@
     currentStep = n;
     const steps = $$('#editorSteps .step');
     steps.forEach((s,i) => s.classList.toggle('hidden', i+1 !== n));
+    const prog = document.getElementById('stepIndicator');
+    if(prog){
+      const pct = (n / steps.length) * 100;
+      prog.setAttribute('aria-valuemax', String(steps.length));
+      prog.setAttribute('aria-valuenow', String(n));
+      prog.setAttribute('aria-valuetext', `Step ${n} of ${steps.length}`);
+      prog.setAttribute('aria-label', `Step ${n} of ${steps.length}`);
+      const bar = prog.querySelector('.bar');
+      if(bar) bar.style.width = pct + '%';
+    }
     if(n === 5) updateConfirm();
   }
   function updateConfirm(){

--- a/index.html
+++ b/index.html
@@ -167,6 +167,9 @@
 
       
 <section id="editorView" class="view">
+  <div id="stepIndicator" class="step-progress" role="progressbar" aria-valuemin="1" aria-valuemax="5" aria-valuenow="1" aria-valuetext="Step 1 of 5" aria-label="Step 1 of 5" tabindex="0">
+    <div class="bar"></div>
+  </div>
   <div class="card" id="editorSteps">
     <div class="step" data-step="1" id="stepIdentify">
       <h2 class="text-xl mb-2">Identify</h2>

--- a/styles.css
+++ b/styles.css
@@ -152,3 +152,6 @@ input, select, textarea{
 .group-header{ list-style:none; margin: 8px 4px; color: var(--muted); font-weight:600 }
 
 .toast{ position: fixed; bottom: 16px; left: 50%; transform: translateX(-50%); background: var(--panel); color: var(--ink); border:1px solid var(--border); padding:8px 12px; border-radius:12px; display:none; z-index: 9999 }
+
+.step-progress{ margin-bottom:12px; height:8px; background: var(--panel-2); border:1px solid var(--border); border-radius:999px; overflow:hidden }
+.step-progress .bar{ height:100%; width:20%; background: var(--accent); transition:width .2s ease }


### PR DESCRIPTION
## Summary
- add progress indicator above editor steps with ARIA support
- style progress bar component
- update `showStep` to update progress state during navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2711647c08324a66c8f737978d69b