### PR TITLE
Enable plant taxonomy autosuggest

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,12 +173,9 @@
   <div class="card" id="editorSteps">
     <div class="step" data-step="1" id="stepIdentify">
       <h2 class="text-xl mb-2">Identify</h2>
-      <input id="plantName" placeholder="Plant name" class="px-3 py-2 rounded-xl border w-full mb-2" />
+      <input id="plantName" placeholder="Plant name" class="px-3 py-2 rounded-xl border w-full mb-2" autocomplete="off" />
+      <div id="taxoResults" class="taxo-suggestions mb-2"></div>
       <input id="plantPhoto" type="file" accept="image/*" capture="environment" class="mb-2" />
-      <div class="actions gap-2 mb-2">
-        <button type="button" id="lookupTaxonomy" class="btn">Lookup</button>
-      </div>
-      <div id="taxoResults" class="taxo-suggestions mb-4"></div>
       <div class="actions gap-2">
         <button type="button" class="btn" id="cancelEdit">Cancel</button>
         <button type="button" data-next class="btn primary">Next</button>

--- a/styles.css
+++ b/styles.css
@@ -81,8 +81,10 @@ main{ padding: 16px; max-width: 900px; margin: 0 auto }
 .science-grid{ display:grid; grid-template-columns: repeat(4, 1fr); gap:.75rem; align-items:end }
 .science .label{ color:var(--muted); font-size:.9rem; margin-bottom:4px }
 .muted{ color: var(--muted) }
-.taxo-suggestions{ display:flex; flex-wrap:wrap; gap:.4rem; margin-top:.5rem }
-.taxo-suggestions .sugg{ cursor:pointer; border:1px solid var(--border); background: var(--panel-2); padding:.25rem .5rem; border-radius:999px; font-size:.9rem }
+  .taxo-suggestions{ display:none; flex-direction:column; margin-top:.25rem; border:1px solid var(--border); background:var(--panel-2); border-radius:4px; max-height:12rem; overflow-y:auto; }
+  .taxo-suggestions.show{ display:flex; }
+  .taxo-suggestions .sugg{ cursor:pointer; padding:.25rem .5rem; }
+  .taxo-suggestions .sugg.active{ background:var(--accent); color:#fff; }
 .wx-pill{ border-color: color-mix(in oklab, var(--accent) 50%, var(--border)); background: var(--panel-2); color: var(--ink) }
 .grid-3{ display:grid; grid-template-columns: repeat(3, 1fr); gap:.5rem }
 .task-field{ display:grid; grid-template-columns: 1fr 120px; gap:.5rem }


### PR DESCRIPTION
## Summary
- replace manual taxonomy lookup button with autosuggest dropdown
- add debounced API querying for plant name suggestions
- support keyboard navigation and auto-filling family/genus/species

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b271fd37408324882f2103dc20b0a0