### PR TITLE
Add plant photo preview with cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -68,7 +68,21 @@
   const stepData = {};
   let taxoSuggestions = [];
   let activeTaxo = -1;
+  let photoObjectURL = null;
+
+  function clearPhotoPreview(){
+    const preview = document.getElementById('photoPreview');
+    if(preview) preview.innerHTML = '';
+    const input = document.getElementById('plantPhoto');
+    if(input) input.value = '';
+    if(photoObjectURL){
+      URL.revokeObjectURL(photoObjectURL);
+      photoObjectURL = null;
+    }
+  }
+
   function showStep(n){
+    if(currentStep === 1 && n !== 1) clearPhotoPreview();
     currentStep = n;
     const steps = $$('#editorSteps .step');
     steps.forEach((s,i) => s.classList.toggle('hidden', i+1 !== n));
@@ -97,6 +111,7 @@
   // Views
   const views = {
     showDashboard(){
+      clearPhotoPreview();
       $('#editorView').classList.remove('active');
       $('#dashboardView').classList.add('active');
       $('#plantsPage').classList.remove('active');
@@ -107,6 +122,7 @@
     showEditor(plant){
       $('#dashboardView').classList.remove('active');
       $('#editorView').classList.add('active');
+      clearPhotoPreview();
       stepData.id = plant?.id || '';
       stepData.carePlan = plant?.carePlan || null;
       stepData.potSizeIn = plant?.potSizeIn || 6;
@@ -599,7 +615,7 @@
 
   // Form handling
   $('#addPlantBtn').addEventListener('click', () => views.showEditor(null));
-  $('#cancelEdit').addEventListener('click', () => views.showDashboard());
+  $('#cancelEdit').addEventListener('click', () => { clearPhotoPreview(); views.showDashboard(); });
   // Seed demo data
   const seedBtn = document.getElementById('seedBtn');
   if(seedBtn){
@@ -646,6 +662,27 @@
       }else if(e.key === 'Enter' && activeTaxo >= 0){
         e.preventDefault();
         items[activeTaxo].click();
+      }
+    });
+
+    // Photo preview
+    const photoInput = document.getElementById('plantPhoto');
+    photoInput.addEventListener('change', e => {
+      if(photoObjectURL){
+        URL.revokeObjectURL(photoObjectURL);
+        photoObjectURL = null;
+      }
+      const file = e.target.files[0];
+      const prev = document.getElementById('photoPreview');
+      if(!file){
+        if(prev) prev.innerHTML = '';
+        return;
+      }
+      photoObjectURL = URL.createObjectURL(file);
+      if(prev){
+        prev.innerHTML = `<img src="${photoObjectURL}" alt="Plant photo" class="mb-2 max-w-full rounded border"/><button type="button" class="btn" id="removePhoto">Remove</button>`;
+        const btn = document.getElementById('removePhoto');
+        if(btn) btn.addEventListener('click', clearPhotoPreview);
       }
     });
 

--- a/index.html
+++ b/index.html
@@ -176,6 +176,7 @@
       <input id="plantName" placeholder="Plant name" class="px-3 py-2 rounded-xl border w-full mb-2" autocomplete="off" />
       <div id="taxoResults" class="taxo-suggestions mb-2"></div>
       <input id="plantPhoto" type="file" accept="image/*" capture="environment" class="mb-2" />
+      <div id="photoPreview" class="mb-2"></div>
       <div class="actions gap-2">
         <button type="button" class="btn" id="cancelEdit">Cancel</button>
         <button type="button" data-next class="btn primary">Next</button>


### PR DESCRIPTION
## Summary
- add photo preview container to editor step
- preview selected plant photo with option to remove
- revoke temporary image URLs when leaving the step to prevent memory leaks

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b273428e108324ab6b6e0a7e3cedf5