### PR TITLE
feat: add plant detail component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,11 @@
   "packages": {
     "": {
       "name": "plant-tracker-pwa",
+      "dependencies": {
+        "lucide-react": "^0.378.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      },
       "devDependencies": {
         "tailwindcss": "^3.4.9"
       }
@@ -606,6 +611,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -626,12 +637,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.378.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.378.0.tgz",
+      "integrity": "sha512-u6EPU8juLUk9ytRcyapkWI18epAv3RU+6+TC23ivjR0e+glWKBobFeSgRwOIJihzktILQuy6E0E80P2jVTDR5g==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -996,6 +1028,31 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
+      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -1073,6 +1130,15 @@
       "license": "MIT",
       "dependencies": {
         "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -7,5 +7,10 @@
   },
   "devDependencies": {
     "tailwindcss": "^3.4.9"
+  },
+  "dependencies": {
+    "lucide-react": "^0.378.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/src/components/PlantDetail.tsx
+++ b/src/components/PlantDetail.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useState } from "react";
+import { Droplet, Sun, Thermometer, ChevronDown, ChevronUp } from "lucide-react";
+
+export interface PlantMetadata {
+  name: string;
+  species?: string;
+  location?: string;
+  imageUrl?: string;
+}
+
+export interface HydrationStatus {
+  /** Hydration percentage from 0-100 */
+  level: number;
+  /** ISO string or human readable last watered date */
+  lastWatered?: string;
+}
+
+export interface CareMetrics {
+  /** Hours of sunlight the plant receives daily */
+  sunlight?: number;
+  /** Current temperature around the plant (°C) */
+  temperature?: number;
+  /** Relative humidity percentage */
+  humidity?: number;
+}
+
+export interface PlantDetailProps {
+  plant: PlantMetadata;
+  hydration: HydrationStatus;
+  metrics: CareMetrics;
+}
+
+const size = 120;
+const stroke = 8;
+const radius = (size - stroke) / 2;
+const circumference = 2 * Math.PI * radius;
+
+export const PlantDetail: React.FC<PlantDetailProps> = ({ plant, hydration, metrics }) => {
+  const [expanded, setExpanded] = useState(false);
+  const [dashOffset, setDashOffset] = useState(circumference);
+
+  useEffect(() => {
+    const progress = Math.min(Math.max(hydration.level, 0), 100) / 100;
+    setDashOffset(circumference - progress * circumference);
+  }, [hydration.level]);
+
+  const stats = [
+    { icon: Sun, label: "Sun", value: metrics.sunlight ? `${metrics.sunlight}h` : "--" },
+    { icon: Thermometer, label: "Temp", value: metrics.temperature ? `${metrics.temperature}°C` : "--" },
+    { icon: Droplet, label: "Humidity", value: metrics.humidity ? `${metrics.humidity}%` : "--" },
+  ];
+
+  return (
+    <div className="bg-white rounded-xl shadow-md p-6 max-w-sm mx-auto">
+      <div className="flex items-center space-x-4">
+        {plant.imageUrl && (
+          <img src={plant.imageUrl} alt={plant.name} className="w-16 h-16 rounded-lg object-cover" />
+        )}
+        <div>
+          <h2 className="text-xl font-semibold">{plant.name}</h2>
+          {plant.species && <p className="text-sm text-gray-500">{plant.species}</p>}
+        </div>
+      </div>
+
+      <div className="relative mx-auto mt-6 w-[120px] h-[120px]">
+        <svg
+          width={size}
+          height={size}
+          className="transform -rotate-90"
+          viewBox={`0 0 ${size} ${size}`}
+        >
+          <circle
+            stroke="currentColor"
+            className="text-gray-200"
+            strokeWidth={stroke}
+            fill="transparent"
+            r={radius}
+            cx={size / 2}
+            cy={size / 2}
+          />
+          <circle
+            stroke="currentColor"
+            className="text-blue-500 transition-all duration-700 ease-out"
+            strokeWidth={stroke}
+            strokeLinecap="round"
+            fill="transparent"
+            r={radius}
+            cx={size / 2}
+            cy={size / 2}
+            style={{
+              strokeDasharray: `${circumference} ${circumference}`,
+              strokeDashoffset: dashOffset,
+            }}
+          />
+        </svg>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <span className="text-xl font-bold">{hydration.level}%</span>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-3 gap-4 mt-6">
+        {stats.map(({ icon: Icon, label, value }) => (
+          <div key={label} className="flex flex-col items-center">
+            <Icon className="w-6 h-6 mb-1" />
+            <span className="text-sm font-semibold">{value}</span>
+            <span className="text-xs text-gray-500">{label}</span>
+          </div>
+        ))}
+      </div>
+
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="mt-6 flex items-center text-sm text-green-600"
+      >
+        {expanded ? (
+          <ChevronUp className="w-4 h-4 mr-1" />
+        ) : (
+          <ChevronDown className="w-4 h-4 mr-1" />
+        )}
+        {expanded ? "Hide details" : "More details"}
+      </button>
+
+      {expanded && (
+        <div className="mt-4 space-y-2 text-sm text-gray-600">
+          {plant.location && (
+            <p>
+              <span className="font-medium">Location:</span> {plant.location}
+            </p>
+          )}
+          {hydration.lastWatered && (
+            <p>
+              <span className="font-medium">Last watered:</span> {hydration.lastWatered}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PlantDetail;
+


### PR DESCRIPTION
## Summary
- add PlantDetail React component with hydration ring, quick stats, and details panel
- expose hydration, metadata, and care metrics props
- install React and lucide-react dependencies

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2750c6e788324aa990629c56135ed