### PR TITLE
Add numeric pot size and chip selectors

### DIFF
--- a/app.js
+++ b/app.js
@@ -126,12 +126,22 @@
       stepData.id = plant?.id || '';
       stepData.carePlan = plant?.carePlan || null;
       stepData.potSizeIn = plant?.potSizeIn || 6;
+      stepData.material = plant?.material || 'plastic';
       stepData.soilType = plant?.soilType || 'generic';
       stepData.hasDrain = plant?.hasDrain !== false;
       $('#plantName').value = plant?.name || '';
       $('#isOutdoor').checked = plant?.inout === 'outdoor';
       $('#potSize').value = String(stepData.potSizeIn);
-      $('#soilType').value = stepData.soilType;
+      $$('#materialChips .chip').forEach(b => {
+        const sel = b.dataset.material === stepData.material;
+        b.classList.toggle('selected', sel);
+        b.setAttribute('aria-checked', sel ? 'true' : 'false');
+      });
+      $$('#soilChips .chip').forEach(b => {
+        const sel = b.dataset.soil === stepData.soilType;
+        b.classList.toggle('selected', sel);
+        b.setAttribute('aria-checked', sel ? 'true' : 'false');
+      });
       $('#hasDrain').checked = stepData.hasDrain;
       if(stepData.carePlan){
         const oz = (stepData.carePlan.waterMl*0.033814).toFixed(1);
@@ -755,9 +765,24 @@
       const tag = document.getElementById('weatherTag'); if(tag) tag.textContent = '';
     });
 
-    // Pot & soil inputs
-    document.getElementById('potSize').addEventListener('change', e => { stepData.potSizeIn = parseInt(e.target.value,10); });
-    document.getElementById('soilType').addEventListener('change', e => { stepData.soilType = e.target.value; });
+    // Pot, material, and soil inputs
+    document.getElementById('potSize').addEventListener('change', e => { stepData.potSizeIn = parseFloat(e.target.value); });
+    $$('#materialChips .chip').forEach(btn => {
+      btn.addEventListener('click', () => {
+        stepData.material = btn.dataset.material;
+        $$('#materialChips .chip').forEach(b => { b.classList.remove('selected'); b.setAttribute('aria-checked','false'); });
+        btn.classList.add('selected');
+        btn.setAttribute('aria-checked','true');
+      });
+    });
+    $$('#soilChips .chip').forEach(btn => {
+      btn.addEventListener('click', () => {
+        stepData.soilType = btn.dataset.soil;
+        $$('#soilChips .chip').forEach(b => { b.classList.remove('selected'); b.setAttribute('aria-checked','false'); });
+        btn.classList.add('selected');
+        btn.setAttribute('aria-checked','true');
+      });
+    });
     document.getElementById('hasDrain').addEventListener('change', e => { stepData.hasDrain = e.target.checked; });
 
     // Care plan generation
@@ -794,6 +819,7 @@
         species: stepData.species || '',
         potSizeIn: stepData.potSizeIn,
         potSize: potCategoryFromInches(stepData.potSizeIn),
+        material: stepData.material,
         soilType: stepData.soilType,
         hasDrain: stepData.hasDrain,
         inout: stepData.inout || ($('#isOutdoor').checked ? 'outdoor' : 'indoor'),

--- a/index.html
+++ b/index.html
@@ -203,17 +203,17 @@
     <div class="step hidden" data-step="3" id="stepPot">
       <h2 class="text-xl mb-2">Pot & Soil</h2>
       <div class="grid-2 gap-2 mb-4">
-        <select id="potSize" class="px-3 py-2 rounded-xl border">
-          <option value="4">4"</option>
-          <option value="6" selected>6"</option>
-          <option value="8">8"</option>
-          <option value="10">10"</option>
-        </select>
-        <select id="soilType" class="px-3 py-2 rounded-xl border">
-          <option value="generic" selected>Generic potting mix</option>
-          <option value="aroid">Aroid/tropical mix</option>
-          <option value="cactus">Cactus/succulent mix</option>
-        </select>
+        <input id="potSize" type="number" step="0.5" min="0" class="px-3 py-2 rounded-xl border" aria-label="Pot size (inches)" />
+        <div id="materialChips" class="flex gap-2" role="radiogroup" aria-label="Pot material">
+          <button type="button" class="chip" role="radio" aria-checked="false" data-material="plastic" aria-label="Plastic pot"><span aria-hidden="true">🪣</span></button>
+          <button type="button" class="chip" role="radio" aria-checked="false" data-material="terracotta" aria-label="Terracotta pot"><span aria-hidden="true">🏺</span></button>
+          <button type="button" class="chip" role="radio" aria-checked="false" data-material="ceramic" aria-label="Ceramic pot"><span aria-hidden="true">🍶</span></button>
+        </div>
+      </div>
+      <div id="soilChips" class="flex gap-2 mb-4" role="radiogroup" aria-label="Soil type">
+        <button type="button" class="chip" role="radio" aria-checked="false" data-soil="generic" aria-label="Generic potting mix"><span aria-hidden="true">🌱</span></button>
+        <button type="button" class="chip" role="radio" aria-checked="false" data-soil="aroid" aria-label="Aroid or tropical mix"><span aria-hidden="true">🪴</span></button>
+        <button type="button" class="chip" role="radio" aria-checked="false" data-soil="cactus" aria-label="Cactus or succulent mix"><span aria-hidden="true">🌵</span></button>
       </div>
       <label class="flex items-center gap-2 mb-4"><input type="checkbox" id="hasDrain" checked />Drainage holes</label>
       <div class="actions gap-2">

--- a/styles.css
+++ b/styles.css
@@ -152,6 +152,8 @@ input, select, textarea{
 #locationChips .chip{ border:1px solid var(--border); background: var(--panel-2); padding:.25rem .5rem; border-radius:999px; cursor:pointer }
 #locationChips .chip.selected{ background: var(--accent); color: var(--panel); border-color: var(--accent) }
 #locationChips input{ border:1px solid var(--border); background: var(--panel-2); padding:.25rem .5rem; border-radius:999px }
+#soilChips .chip, #materialChips .chip{ border:1px solid var(--border); background: var(--panel-2); padding:.25rem .5rem; border-radius:999px; cursor:pointer }
+#soilChips .chip.selected, #materialChips .chip.selected{ background: var(--accent); color: var(--panel); border-color: var(--accent) }
 .task-chip{ display:flex; align-items:center; gap:.4rem; border:1px solid var(--border); background: var(--panel-2); padding:.25rem .5rem; border-radius:999px }
 .task-chip button{ border:none; background:transparent; color:var(--accent-2); cursor:pointer }
 .group-header{ list-style:none; margin: 8px 4px; color: var(--muted); font-weight:600 }


### PR DESCRIPTION
## Summary
- Replace pot size drop-down with numeric input and add chip controls for pot material and soil type
- Style new chip groups and maintain selected state
- Track pot size, material, and soil type in the editor flow and stored plant data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b2757efa3883249a44c54d495d5edc