### PR TITLE
Render plant detail with React component

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
+import { PlantDetail } from './components/PlantDetail.tsx';
+
+// Expose React and the PlantDetail component for non-React scripts
+window.React = React;
+window.ReactDOM = ReactDOM;
+window.PlantDetail = PlantDetail;
 
 ReactDOM.createRoot(document.getElementById('react-root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- Replace DOM-based `showPlantDetail` with a React-driven implementation that fetches plant data and renders `<PlantDetail>`.
- Extend `PlantDetail` to expose `onWater` and `onPhoto` callbacks, enabling updates to `PlantDB`.
- Expose React and `PlantDetail` globally for integration with legacy scripts.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b27ac87ba083248d73a2ab9c2ca36d