### PR TITLE
chore: remove App component and mount RoomsView directly

### DIFF
--- a/src/RoomsView.jsx
+++ b/src/RoomsView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function App() {
+export default function RoomsView() {
   return (
     <div className="p-4">
       <h2 className="text-xl font-bold">React Ready</h2>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import App from './App.jsx';
+import RoomsView from './RoomsView.jsx';
 
 ReactDOM.createRoot(document.getElementById('react-root')).render(
   <React.StrictMode>
-    <App />
+    <RoomsView />
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- drop legacy App wrapper and render RoomsView at the root
- simplify entry point to mount RoomsView directly

## Testing
- `npm test` *(fails: Missing script "test"*)

------
https://chatgpt.com/codex/tasks/task_e_68b27bd806848324b9cc049feb16292e