### PR TITLE
chore: add placeholder test script and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ Open `index.html` in a modern browser. No build step required.
 3. **Open the built files**
    After the build finishes, open `health.html` (or `index.html`) in a browser to verify the local build.
 
+## Tests
+
+Currently there are no automated tests. Run the placeholder test script with:
+
+```bash
+npm test
+```
+
+This will print "No tests yet" until real tests are added.
+
 ## Current Features
 
 - Add/edit plants with species, light level, pot size, and base watering interval

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "scripts": {
     "build": "tailwindcss -c tailwind.config.js -i src/tailwind.css -o tailwind.css --minify && vite build && node scripts/build-output.js",
-    "dev": "vite"
+    "dev": "vite",
+    "test": "echo \"No tests yet\""
   },
   "devDependencies": {
 


### PR DESCRIPTION
## Summary
- add npm test script that prints placeholder message
- document how to run tests
- run tests in GitHub Actions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b27bdb3a448324906237b389d3f4bd