### PR TITLE
feat: add watering history chart

### DIFF
--- a/app.js
+++ b/app.js
@@ -1040,7 +1040,7 @@
         onWater: async () => {
           plant.lastWatered = todayISO();
           plant.history = plant.history || [];
-          plant.history.push({ type: 'water', at: todayISO() });
+          plant.history.push({ type: 'water', at: todayISO(), amount: plant.carePlan?.waterMl });
           await PlantDB.put(plant);
           render();
         },


### PR DESCRIPTION
## Summary
- derive timeline events and 30 day watering data from plant history
- show grouped care timeline with lucide icons
- show bar chart for watering history and include amount in saved events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b280526c888324903e5fab1412b7fa